### PR TITLE
Fix(dtfreq): correct missing total row

### DIFF
--- a/ado/dtfreq.ado
+++ b/ado/dtfreq.ado
@@ -1,6 +1,6 @@
 capture program drop dtfreq
 program define dtfreq
-    *! Version 1.0.0 Hafiz 02Jun2025
+    *! Version 1.0.1 Hafiz 03Jun2025
     * Module to produce frequency dataset
     version 16
     syntax anything(id="varlist") [if] [in] [aweight fweight iweight pweight] [using/] [, df(string) by(varname numeric) cross(varname numeric) BINary FOrmat(string) noMISS save(string asis) excel(string) STATs(namelist max=3) TYpe(namelist max=2) Clear REPlace]
@@ -306,9 +306,14 @@ program define _crosstotal
                     generate cellprop`suffix' = `tvar' / total_all
                     generate rowprop`suffix' = cellprop`suffix'  // Same as cellprop in totals
                     generate colprop`suffix' = 1
+                    generate cellpct`suffix' = cellprop`suffix' * 100
+                    generate rowpct`suffix' = rowprop`suffix' * 100
+                    generate colpct`suffix' = colprop`suffix' * 100
                     replace freq`suffix' = `tvar'   // Set freq to column total
                 }
             }
+            generate prop_all = 1
+            generate pct_all = 100
             replace `rowfreq' = total_all  // Set row frequency to overall total
             tempfile totalrows
             save `totalrows'
@@ -317,10 +322,10 @@ program define _crosstotal
         // Append and sort
         append using `totalrows'
         generate sortorder = 0
-        quietly replace sortorder = 1 if `vallabname' == "Total"
+        replace sortorder = 1 if `vallabname' == "Total"
         sort varname sortorder
         drop sortorder
-        quietly replace varlab = "Grand total" if `vallabname' == "Total"
+        replace varlab = "Grand total" if `vallabname' == "Total"
     }
 end
 // * Adds nice names to all output columns

--- a/ado/dtfreq.sthlp
+++ b/ado/dtfreq.sthlp
@@ -253,6 +253,7 @@ command. Can only be used with {cmd:save()}.
 {synopt:{cmd:cellpct*}}cell percentages{p_end}
 {synopt:{cmd:*total*}}total counts for denominators{p_end}
 
+{pstd}{bf:prop_all} and {bf:pct_all} show the overall proportion (1) and percentage (100) for the total row when using {opt cross()}. They help identify the grand total in the results.{p_end}
 {pstd}Variable presence depends on {opt stats()} and {opt type()} options:{p_end}
 
 {phang2}• {opt stats(col)} creates {cmd:colprop*} and/or {cmd:colpct*} variables{p_end}

--- a/ado/dtfreq.sthlp
+++ b/ado/dtfreq.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.0 02Jun2025}{...}
+{* *! version 1.0.1 03Jun2025}{...}
 {vieweralsosee "[R] contract" "help contract"}{...}
 {vieweralsosee "[R] table" "help table"}{...}
 {vieweralsosee "[R] tabstat" "help tabstat"}{...}
@@ -275,7 +275,7 @@ The active frame remains unchanged unless an error occurs during frame switching
 {pstd}GitHub: {browse "https://github.com/hafizarfyanto/dtkit":https://github.com/hafizarfyanto/dtkit}{p_end}
 
 {pstd}
-Program Version: {bf:1.0.0} (02 June 2025)
+Program Version: {bf:1.0.1} (03 June 2025)
 
 {title:Also see}
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,57 +5,62 @@ All notable changes to the dtkit project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dtkit-v1.0.1] - 2025-06-03
+
+### Package Release
+- This update includes an important bug fix for the `dtfreq` command.
+- Component versions included in this release:
+  - **dtfreq: v1.0.1 (Updated)**
+  - dtstat: v1.0.0 (Unchanged)
+  - dtmeta: v1.0.0 (Unchanged)
+
+### Fixed
+- **dtfreq v1.0.1**:
+  - Fixed an issue where the "Total" row in tables created with the `cross()` option sometimes showed incorrect calculations for proportions and percentages. Totals are now accurate.
+
 ## [dtkit-v1.0.0] - 2025-06-02
 
 ### Package Release
-- **Initial stable release** of the dtkit data exploration toolkit for Stata
-- Complete rewrite and standardization of all three core modules
-- Comprehensive test suite with automated tracking and reporting
+- **First official release** of the `dtkit` tools for Stata.
+- All tools (`dtfreq`, `dtstat`, `dtmeta`) have been fully updated for better performance and easier use.
+- Thoroughly tested for reliability.
 
 ### Added
-- **dtstat-v1.0.0**: Enhanced descriptive statistics with frame output
-  - Flexible statistics selection (count, mean, median, sd, min, max, sum, iqr, percentiles)
-  - By-group processing with automatic totals
-  - Respects user-specified format() option instead of always auto-formatting
-  - Multi-sheet Excel export with customizable options
-  - Optional gtools integration for performance boost
-  - Comprehensive error handling and validation
+New tools included in this release:
 
-- **dtfreq-v1.0.0**: Comprehensive frequency analysis and cross-tabulations
-  - One-way and two-way frequency tables with flexible output
-  - Row, column, and cell proportions/percentages
-  - Binary variable reshaping functionality
-  - Cross-tabulation with automatic totals
-  - Value label preservation and intelligent formatting
-  - Excel export with sheet customization
+- **dtstat v1.0.0**: For descriptive statistics.
+  - Choose from many stats (count, mean, median, sd, min, max, sum, iqr, percentiles).
+  - Get stats for groups, with automatic totals.
+  - Uses your chosen number format, instead of auto-formatting.
+  - Export to Excel with multiple sheets and options.
+  - Faster if you have `gtools` installed (optional).
 
-- **dtmeta-v1.0.0**: Dataset metadata extraction into organized frames
-  - Variable metadata extraction (_dtvars frame)
-  - Value label metadata (_dtlabel frame) 
-  - Variable notes extraction (_dtnotes frame)
-  - Dataset information and characteristics (_dtinfo frame)
-  - Multi-sheet Excel export for all metadata frames
-  - Optional detailed reporting with frame access commands
-  - Graceful handling of datasets with no notes/labels
+- **dtfreq v1.0.0**: For frequency tables and cross-tabulations.
+  - Create one-way and two-way tables easily.
+  - Shows row, column, and cell proportions/percentages.
+  - Helps organize data for variables with two categories (e.g., yes/no).
+  - Automatically adds totals to cross-tabulations.
+  - Keeps your value labels and formats numbers smartly.
+  - Export to Excel with options to customize sheets.
+
+- **dtmeta v1.0.0**: To get information about your dataset.
+  - Extracts details about variables, value labels, and notes into new, organized dataset (frames).
+  - Also provides general information about your dataset.
+  - Export all this information to Excel, with multiple sheets.
+  - Includes commands to easily view these new tables.
+  - Works well even if your dataset doesn't have many notes or labels.
 
 ### Improved
-- **Consistent file handling**: All modules use robust `save(string asis)` with compound quotes
-- **Standardized Excel export**: Uniform behavior across all modules with replace/modify options
-- **Enhanced documentation**: Complete help files with practical examples
-- **Test coverage**: Comprehensive test suites with 79 total tests across all modules
-- **Frame management**: Improved creation, labeling, and cleanup of output frames
-
-### Technical
-- **Stata 16+ compatibility**: Leverages modern frame functionality
-- **Weight support**: All weight types (aweight, fweight, iweight, pweight) supported
-- **Conditional processing**: Full support for if/in qualifiers
-- **Error handling**: Robust validation and informative error messages
-
-### Documentation
-- Updated help files with examples matching test patterns
-- Comprehensive README.md with installation and usage instructions
-- BibTeX citation format for academic use
-- Practical examples using standard Stata datasets
+General improvements for all tools:
+- **File Saving**: More reliable when saving files.
+- **Excel Export**: Consistent Excel export options across all tools.
+- **Help Files**: Updated help files with more examples.
+- **Reliability**: Increased reliability from extensive testing.
+- **Table Handling**: Better management of the tables (frames) created by the tools.
+- **Stata Compatibility**: Works with Stata 16 and newer.
+- **Weight Support**: Supports all standard Stata weight types.
+- **Error Messages**: More helpful error messages.
+- **Documentation**: README file updated with clear installation and usage steps. Citation information provided for academic use.
 
 ---
 

--- a/dtkit.pkg
+++ b/dtkit.pkg
@@ -1,10 +1,10 @@
-v 1.0.0
+v 1.0.1
 d dtkit: Data Toolkit for Stata
 d
 d Author: Hafiz Arfyanto
 d Support: email hafizarfyanto@gmail.com
 d
-d Distribution-Date: 02Jun2025
+d Distribution-Date: 03Jun2025
 d
 d This package provides utilities for data analysis in Stata
 d

--- a/stata.toc
+++ b/stata.toc
@@ -1,4 +1,4 @@
-v 1.0.0
+v 1.0.1
 d Data analysis packages
 d
 p dtkit Data Toolkit for Stata


### PR DESCRIPTION
This pull request addresses a bug in `dtfreq.ado` where some variables have missing values in the total row.