### PR TITLE
Fix(dtstat): Remove unused internal subroutine for sample marking

### DIFF
--- a/ado/dtstat.ado
+++ b/ado/dtstat.ado
@@ -1,6 +1,6 @@
 capture program drop dtstat
 program define dtstat
-    *! Version 1.0.0 Hafiz 02Jun2025
+    *! Version 1.0.1 Hafiz 03Jun2025
     * Module to produce descriptive statistics dataset
 
     version 16
@@ -28,16 +28,10 @@ program define dtstat
 
     // * weight and marker
     tempvar touse
-    if "`miss'" == "nomiss" {
-        marksample touse, strok
-    }
-    else {
-        marksample touse, strok novarlist
-    }
+    if "`miss'" == "nomiss" marksample touse, strok
+    else marksample touse, strok novarlist
     local ifcmd "if `touse'"
-    if "`weight'" != "" {
-        local wtexp `"[`weight'`exp']"'
-    }
+    if "`weight'" != "" local wtexp `"[`weight'`exp']"'
 
     // Process statistics options
     _stats, stats(`stats')    
@@ -62,29 +56,6 @@ program define dtstat
             local fullname = "`fullpath'`filename'`extension'"
         }
         frame `df': _toexcel, fullname(`fullname') excel(`excel') replace(`replace')
-    }
-end
-
-// * sample marking
-capture program drop _markobs
-program define _markobs, rclass
-    syntax [if] [in] [aweight fweight iweight pweight], [miss(string)]
-    
-    // Mark sample observations
-    if "`miss'" == "nomiss" {
-        marksample touse, strok
-    }
-    else {
-        marksample touse, strok novarlist
-    }
-
-    return local ifcmd "if `touse'"
-    
-    if "`weight'" != "" {
-        return local wtexp `"[`weight'`exp']"'
-    }
-    else {
-        return local wtexp ""
     }
 end
 

--- a/ado/dtstat.sthlp
+++ b/ado/dtstat.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.0  02Jun2025}{...}
+{* *! version 1.0.1  03Jun2025}{...}
 {vieweralsosee "[R] summarize" "help summarize"}{...}
 {vieweralsosee "[R] collapse" "help collapse"}{...}
 {vieweralsosee "[R] tabstat" "help tabstat"}{...}
@@ -254,7 +254,7 @@ For example, if statistics are calculated for variables {cmd:v1} and {cmd:v2}, a
 {pstd}GitHub: {browse "https://github.com/hafizarfyanto/dtkit":https://github.com/hafizarfyanto/dtkit}{p_end}
 
 {pstd}
-Program Version: {bf:2.1.1} (02 June 2025)
+Program Version: {bf:1.0.1} (03 June 2025)
 
 {title:Dependencies}
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dtkit-v1.0.1] - 2025-06-03
 
 ### Package Release
-- This update includes an important bug fix for the `dtfreq` and `dtstats` commands.
+- This update includes an important bug fix for the `dtfreq` and `dtstat` commands.
 - Component versions included in this release:
   - **dtfreq: v1.0.1 (Updated)**
   - **dtstat: v1.0.1 (Updated)**

--- a/changelog.md
+++ b/changelog.md
@@ -8,16 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dtkit-v1.0.1] - 2025-06-03
 
 ### Package Release
-- This update includes an important bug fix for the `dtfreq` command.
+- This update includes an important bug fix for the `dtfreq` and `dtstats` commands.
 - Component versions included in this release:
   - **dtfreq: v1.0.1 (Updated)**
-  - dtstat: v1.0.0 (Unchanged)
+  - **dtstat: v1.0.1 (Updated)**
   - dtmeta: v1.0.0 (Unchanged)
 
 ### Fixed
 - **dtfreq v1.0.1**:
   - Fixed an issue where the "Total" row in tables created with the `cross()` option sometimes showed incorrect calculations for proportions and percentages. Totals are now accurate.
-
+- **dtstat v1.0.1**:
+  - Fixed unused internal subroutine for sample marking.
+  
 ## [dtkit-v1.0.0] - 2025-06-02
 
 ### Package Release


### PR DESCRIPTION
## Description

This PR removes an unused internal subroutine related to sample marking in `dtstat.ado`, which simplifies the codebase.

## Changes Made

- Removed the unused subroutine `_markobs` from `dtstat.ado`.
- Updated the version comment in `dtstat.ado` to `1.0.1`.
- Updated `CHANGELOG.md` to include this fix under `dtstat v1.0.1` and reflect that `dtkit-v1.0.1` now includes updates for both `dtfreq` and `dtstat`.

