### PR TITLE
Modernize and cleanup help file layouts

### DIFF
--- a/ado/dtfreq.sthlp
+++ b/ado/dtfreq.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.2  25jun2025}{...}
+{* *! version 1.0.2  11mar2026}{...}
 {vieweralsosee "[R] contract" "help contract"}{...}
 {vieweralsosee "[R] table" "help table"}{...}
 {vieweralsosee "[R] tabstat" "help tabstat"}{...}
@@ -10,15 +10,13 @@
 {vieweralsosee "dtparquet" "help dtparquet"}{...}
 {viewerjumpto "Syntax" "dtfreq##syntax"}{...}
 {viewerjumpto "Description" "dtfreq##description"}{...}
-{viewerjumpto "Links to PDF documentation" "dtfreq##linkspdf"}{...}
 {viewerjumpto "Options" "dtfreq##options"}{...}
 {viewerjumpto "Examples" "dtfreq##examples"}{...}
 {viewerjumpto "Stored results" "dtfreq##results"}{...}
 {viewerjumpto "Author" "dtfreq##author"}{...}
 {viewerjumpto "Also see" "dtfreq##also_see"}{...}
 {p2colset 1 16 18 2}{...}
-{p2col:{bf:[D] dtfreq} {hline 2}}Produce comprehensive frequency datasets{p_end}
-{p2col:}({mansection D dtfreq:View complete PDF manual entry}){p_end}
+{p2col:{bf:dtfreq} {hline 2}}Produce comprehensive frequency datasets{p_end}
 {p2colreset}{...}
 
 
@@ -26,12 +24,7 @@
 {title:Syntax}
 
 {p 8 16 2}
-{cmd:dtfreq}
-{varlist}
-[{ifin}]
-[{weight}]
-[{cmd:using} {it:{help filename}}]
-[{cmd:,} {it:options}]
+{cmd:dtfreq} {varlist} [{ifin}] [{weight}] [{cmd:using} {it:{help filename}}] [{cmd:,} {it:options}]
 
 {synoptset 24 tabbed}{...}
 {synopthdr}
@@ -89,13 +82,6 @@ The following list describes the resulting variable names:
 {phang2}o {opt stats(cell)} creates {cmd:cellprop*} and/or {cmd:cellpct*} variables{p_end}
 {phang2}o {opt type(prop)} includes proportion variables{p_end}
 {phang2}o {opt type(pct)} includes percentage variables{p_end}
-
-
-{marker linkspdf}{...}
-{title:Links to PDF documentation}
-
-{pstd}
-No PDF documentation is available for this user-written command.
 
 
 {marker options}{...}
@@ -265,9 +251,10 @@ The active frame remains unchanged throughout execution.
 {marker author}{...}
 {title:Author}
 
-{pstd}Hafiz Arfyanto{p_end}
-{pstd}Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{p_end}
-{pstd}GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}{p_end}
+{pstd}
+Hafiz Arfyanto{break}
+Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{break}
+GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}
 
 {pstd}
 The GitHub repository hosts the latest updates and documentation.

--- a/ado/dtkit.sthlp
+++ b/ado/dtkit.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 2.0.0  06mar2026}{...}
+{* *! version 2.0.1  11mar2026}{...}
 {vieweralsosee "dtfreq" "help dtfreq"}{...}
 {vieweralsosee "dtstat" "help dtstat"}{...}
 {vieweralsosee "dtmeta" "help dtmeta"}{...}
@@ -7,14 +7,12 @@
 {vieweralsosee "" "--"}{...}
 {viewerjumpto "Syntax" "dtkit##syntax"}{...}
 {viewerjumpto "Description" "dtkit##description"}{...}
-{viewerjumpto "Links to PDF documentation" "dtkit##linkspdf"}{...}
 {viewerjumpto "Options" "dtkit##options"}{...}
 {viewerjumpto "Examples" "dtkit##examples"}{...}
 {viewerjumpto "Author" "dtkit##author"}{...}
 {viewerjumpto "Also see" "dtkit##also_see"}{...}
 {p2colset 1 12 14 2}{...}
-{p2col:{bf:[D] dtkit} {hline 2}}Data Toolkit package management{p_end}
-{p2col:}({mansection D dtkit:View complete PDF manual entry}){p_end}
+{p2col:{bf:dtkit} {hline 2}}Data Toolkit package management{p_end}
 {p2colreset}{...}
 
 
@@ -22,8 +20,7 @@
 {title:Syntax}
 
 {p 8 16 2}
-{cmd:dtkit}
-[{cmd:,} {it:options}]
+{cmd:dtkit} [{cmd:,} {it:options}]
 
 {synoptset 20 tabbed}{...}
 {synopthdr}
@@ -69,13 +66,6 @@ It handles installation, updates, and testing across the suite:
 {pstd}
 {cmd:dtkit} without options displays version information and availability status of all components.
 It reports the current installation status and checks for package updates.
-
-
-{marker linkspdf}{...}
-{title:Links to PDF documentation}
-
-{pstd}
-No PDF documentation is available for this user-written command.
 
 
 {marker options}{...}
@@ -129,11 +119,21 @@ It verifies the installation and accessibility of all dtkit commands.
 {opt tests(string)} runs specific test suites.
 Keyword arguments restrict tests to individual commands or functional areas.
 Available options are:
-{break}    {bf:basic} - basic functionality tests
-{break}    {bf:dtfreq} - dtfreq-specific tests  
-{break}    {bf:dtstat} - dtstat-specific tests
-{break}    {bf:dtmeta} - dtmeta-specific tests
-{break}    {bf:dtparquet} - dtparquet-specific tests
+
+{phang2}
+{bf:basic} - basic functionality tests
+
+{phang2}
+{bf:dtfreq} - dtfreq-specific tests
+
+{phang2}
+{bf:dtstat} - dtstat-specific tests
+
+{phang2}
+{bf:dtmeta} - dtmeta-specific tests
+
+{phang2}
+{bf:dtparquet} - dtparquet-specific tests
 
 
 {marker examples}{...}
@@ -167,13 +167,13 @@ Available options are:
 {marker author}{...}
 {title:Author}
 
-{pstd}Hafiz Arfyanto{p_end}
-{pstd}Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{p_end}
-{pstd}GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}{p_end}
+{pstd}
+Hafiz Arfyanto{break}
+Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{break}
+GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}
 
 {pstd}
 Visit {browse "https://github.com/bukanpeneliti/dtkit/issues":GitHub Issues} for questions and suggestions.
-The issue tracker hosts bug reports and feature requests.
 
 
 {marker also_see}{...}

--- a/ado/dtmeta.sthlp
+++ b/ado/dtmeta.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.1  25jun2025}{...}
+{* *! version 1.0.1  11mar2026}{...}
 {vieweralsosee "[R] describe" "help describe"}{...}
 {vieweralsosee "[R] label" "help label"}{...}
 {vieweralsosee "[R] notes" "help notes"}{...}
@@ -10,7 +10,6 @@
 {vieweralsosee "dtparquet" "help dtparquet"}{...}
 {viewerjumpto "Syntax" "dtmeta##syntax"}{...}
 {viewerjumpto "Description" "dtmeta##description"}{...}
-{viewerjumpto "Links to PDF documentation" "dtmeta##linkspdf"}{...}
 {viewerjumpto "Options" "dtmeta##options"}{...}
 {viewerjumpto "Remarks" "dtmeta##remarks"}{...}
 {viewerjumpto "Examples" "dtmeta##examples"}{...}
@@ -18,8 +17,7 @@
 {viewerjumpto "Author" "dtmeta##author"}{...}
 {viewerjumpto "Also see" "dtmeta##also_see"}{...}
 {p2colset 1 16 18 2}{...}
-{p2col:{bf:[D] dtmeta} {hline 2}}Extract dataset metadata into multiple frames{p_end}
-{p2col:}({mansection D dtmeta:View complete PDF manual entry}){p_end}
+{p2col:{bf:dtmeta} {hline 2}}Extract dataset metadata into multiple frames{p_end}
 {p2colreset}{...}
 
 
@@ -27,9 +25,7 @@
 {title:Syntax}
 
 {p 8 16 2}
-{cmd:dtmeta}
-[{cmd:using} {it:{help filename}}]
-[{cmd:,} {it:options}]
+{cmd:dtmeta} [{cmd:using} {it:{help filename}}] [{cmd:,} {it:options}]
 
 {synoptset 20 tabbed}{...}
 {synopthdr}
@@ -58,13 +54,6 @@ The command creates up to four frames, each containing different aspects of the 
 {pstd}
 {cmd:dtmeta} processes the dataset in memory or reads metadata from an external {cmd:.dta} file via {cmd:using}.
 Without {opt clear}, {cmd:dtmeta} leaves the data in memory unchanged when processing an external file.
-
-
-{marker linkspdf}{...}
-{title:Links to PDF documentation}
-
-{pstd}
-No PDF documentation is available for this user-written command.
 
 
 {marker options}{...}
@@ -258,9 +247,10 @@ Without {opt clear}, {cmd:dtmeta} also preserves the current dataset when readin
 {marker author}{...}
 {title:Author}
 
-{pstd}Hafiz Arfyanto{p_end}
-{pstd}Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{p_end}
-{pstd}GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}{p_end}
+{pstd}
+Hafiz Arfyanto{break}
+Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{break}
+GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}
 
 {pstd}
 For questions and suggestions, visit {browse "https://github.com/bukanpeneliti/dtkit/issues":GitHub Issues}.

--- a/ado/dtparquet.sthlp
+++ b/ado/dtparquet.sthlp
@@ -1,21 +1,21 @@
 {smcl}
-{* *! version 2.0.0  06mar2026}{...}
+{* *! version 2.0.1  11mar2026}{...}
+{vieweralsosee "dtmeta" "help dtmeta"}{...}
+{vieweralsosee "dtkit" "help dtkit"}{...}
 {vieweralsosee "[D] use" "help use"}{...}
 {vieweralsosee "[D] save" "help save"}{...}
 {vieweralsosee "[D] import" "help import"}{...}
 {vieweralsosee "[D] export" "help export"}{...}
-{vieweralsosee "dtmeta" "help dtmeta"}{...}
 {vieweralsosee "frames" "help frames"}{...}
 {viewerjumpto "Syntax" "dtparquet##syntax"}{...}
 {viewerjumpto "Description" "dtparquet##description"}{...}
-{viewerjumpto "Links to PDF documentation" "dtparquet##linkspdf"}{...}
 {viewerjumpto "Options" "dtparquet##options"}{...}
+{viewerjumpto "Remarks" "dtparquet##remarks"}{...}
 {viewerjumpto "Examples" "dtparquet##examples"}{...}
 {viewerjumpto "Troubleshooting" "dtparquet##troubleshooting"}{...}
 {viewerjumpto "Author" "dtparquet##author"}{...}
 {p2colset 1 21 23 2}{...}
-{p2col:{bf:[D] dtparquet} {hline 2}}High-performance Parquet I/O via native plugin paths{p_end}
-{p2col:}({mansection D dtparquet:View complete PDF manual entry}){p_end}
+{p2col:{bf:dtparquet} {hline 2}}High-performance Parquet I/O via native plugin{p_end}
 {p2colreset}{...}
 
 
@@ -26,32 +26,19 @@
 Memory operations
 
 {p 8 16 2}
-{cmd:dtparquet} {opt sa:ve}
-{it:{help filename}}
-[{cmd:,} {it:save_options}]
+{cmd:dtparquet} {opt sa:ve} {it:{help filename}} [{cmd:,} {it:save_options}]
 
 {p 8 16 2}
-{cmd:dtparquet} {opt u:se}
-[{varlist}]
-[{it:if}]
-[{it:in}]
-{cmd:using} {it:{help filename}}
-[{cmd:,} {it:use_options}]
+{cmd:dtparquet} {opt u:se} [{varlist}] [{it:if}] [{it:in}] {cmd:using} {it:{help filename}} [{cmd:,} {it:use_options}]
 
 {pstd}
 Disk operations (no data loaded into active memory)
 
 {p 8 16 2}
-{cmd:dtparquet} {opt exp:ort}
-{it:{help filename:parquetfile}}
-{cmd:using} {it:{help filename:dtafile}}
-[{cmd:,} {it:export_options}]
+{cmd:dtparquet} {opt exp:ort} {it:{help filename:parquetfile}} {cmd:using} {it:{help filename:dtafile}} [{cmd:,} {it:export_options}]
 
 {p 8 16 2}
-{cmd:dtparquet} {opt imp:ort}
-{it:{help filename:dtafile}}
-{cmd:using} {it:{help filename:parquetfile}}
-[{cmd:,} {it:import_options}]
+{cmd:dtparquet} {opt imp:ort} {it:{help filename:dtafile}} {cmd:using} {it:{help filename:parquetfile}} [{cmd:,} {it:import_options}]
 
 
 {marker description}{...}
@@ -59,35 +46,27 @@ Disk operations (no data loaded into active memory)
 
 {pstd}
 {cmd:dtparquet} provides high-performance reading and writing of Apache Parquet
-files.  It serves as a bridge between Stata and the Parquet ecosystem through
-native plugin execution and Stata's {help sfi:Stata Function Interface (SFI)}.
+files, offering a fast and efficient alternative to standard Stata I/O for
+large-scale datasets.
 
 {pstd}
-Key features include:
+Key features:
 
 {phang2}
-o {bf:Metadata Preservation}: Automatically integrates with {help dtmeta} to
-store and restore value labels, variable labels, and notes within the Parquet
-file footer.
+o {bf:Performance}: Leverages a native Rust engine with adaptive batching 
+and pushdown filtering for maximum throughput.
 
 {phang2}
-o {bf:Frame Isolation}: Disk operations ({cmd:import} and {cmd:export}) run in
-temporary frames so the active dataset is preserved.
+o {bf:Metadata Preservation}: Automatically stores and restores value labels, 
+variable labels, and notes using {help dtmeta}.
 
 {phang2}
-o {bf:Safer Writes}: Non-partitioned Parquet writes use temporary files
-({it:.tmp}) before final placement, reducing partial-write risk.
+o {bf:Frame Isolation}: Disk-to-disk operations ({cmd:import} and {cmd:export}) 
+preserve the active dataset by running in background frames.
 
 {phang2}
-o {bf:Type Safety}: Handles complex Stata types including {it:strL} and provides
-options to handle precision limits of 64-bit integers.
-
-
-{marker linkspdf}{...}
-{title:Links to PDF documentation}
-
-{pstd}
-No PDF documentation is available for this user-written command.
+o {bf:Type Safety}: Full support for complex Stata types, including {it:strL} 
+and precision-sensitive 64-bit integers.
 
 
 {marker options}{...}
@@ -112,9 +91,11 @@ Options are presented under the following headings:
 {synopthdr :save_options}
 {synoptline}
 {synopt :{opt re:place}}overwrite existing file{p_end}
-{synopt :{opt nol:abel}}suppress writing custom Stata metadata (value labels, etc.){p_end}
-{synopt :{opt ch:unksize(#)}}batch size for processing; default {cmd:0} uses adaptive sizing{p_end}
-{synopt :{opt com:press(codec)}}compression codec; default {cmd:fast}. Presets: {cmd:fast} (lz4), {cmd:balanced} (zstd), {cmd:archive} (brotli). Also allowed: {cmd:lz4}, {cmd:uncompressed}, {cmd:snappy}, {cmd:gzip}, {cmd:lzo}, {cmd:brotli}, {cmd:zstd}{p_end}
+{synopt :{opt nol:abel}}suppress writing custom Stata metadata (labels, notes){p_end}
+{synopt :{opt ch:unksize(#)}}batch size for processing; {cmd:0} uses adaptive sizing{p_end}
+{synopt :{opt com:press(codec)}}compression codec; default {cmd:fast} (lz4). 
+Presets: {cmd:fast}, {cmd:balanced} (zstd), {cmd:archive} (brotli). 
+Also allowed: {cmd:lz4}, {cmd:snappy}, {cmd:gzip}, {cmd:brotli}, {cmd:zstd}, {cmd:lzo}, {cmd:uncompressed}.{p_end}
 {synopt :{opt part:itionby(varlist)}}write partitioned Parquet output by variables{p_end}
 {synoptline}
 
@@ -128,7 +109,8 @@ Options are presented under the following headings:
 {synopt :{opt nol:abel}}suppress reading custom Stata metadata{p_end}
 {synopt :{opt ch:unksize(#)}}batch size for processing; default is 50,000{p_end}
 {synopt :{opt all:string}}import 64-bit integers as strings to preserve precision{p_end}
-{synopt :{opt cat:mode(encode|raw|both)}}handling for foreign categorical/enum columns; default {cmd:encode}{p_end}
+{synopt :{opt cat:mode(mode)}}handling for foreign categorical/enum columns:
+{cmd:encode} (default), {cmd:raw}, or {cmd:both}.{p_end}
 {synoptline}
 
 {marker export_options}{...}
@@ -139,7 +121,6 @@ Options are presented under the following headings:
 {synoptline}
 {synopt :{opt re:place}}overwrite existing file{p_end}
 {synopt :{opt nol:abel}}suppress writing custom Stata metadata{p_end}
-{synopt :{opt ch:unksize(#)}}accepted for compatibility; currently not applied by {cmd:dtparquet export}{p_end}
 {synoptline}
 
 {marker import_options}{...}
@@ -150,7 +131,6 @@ Options are presented under the following headings:
 {synoptline}
 {synopt :{opt re:place}}overwrite existing file{p_end}
 {synopt :{opt nol:abel}}suppress reading custom Stata metadata{p_end}
-{synopt :{opt ch:unksize(#)}}accepted for compatibility; currently not applied by {cmd:dtparquet import}{p_end}
 {synopt :{opt all:string}}import 64-bit integers as strings to preserve precision{p_end}
 {synoptline}
 
@@ -158,34 +138,69 @@ Options are presented under the following headings:
 Global option: {cmd:notimer} suppresses the elapsed-time message.
 
 
+{marker remarks}{...}
+{title:Remarks}
+
+{pstd}
+{bf:Precision of 64-bit Integers}
+{break}Stata's {cmd:double} type has 53 bits of mantissa, meaning it can only 
+represent integers exactly up to 9,007,199,254,740,992 (2^53). Parquet files 
+from other systems (like Spark or Python) often contain 64-bit integers that 
+exceed this limit. By default, {cmd:dtparquet} will cast these to {cmd:double}, 
+potentially losing precision. Use the {opt allstring} option to import these 
+columns as Stata {it:strL} variables to preserve the exact values.
+
+{pstd}
+{bf:Performance and Pushdown Filtering}
+{break}{cmd:dtparquet} is optimized for speed. When using {cmd:dtparquet use}, 
+Stata's {help if} and {help in} qualifiers are "pushed down" to the native 
+plugin. This allows the plugin to filter rows during the scan phase, 
+transferring only the required data into Stata memory. This is significantly 
+faster than loading the entire file and filtering in Stata.
+
+{pstd}
+{bf:Categorical Data}
+{break}Foreign Parquet files often contain "Categorical" or "Enum" types. 
+{cmd:dtparquet} can handle these in three ways via {opt catmode()}:
+{break}{cmd:encode}: Converts categories to Stata value labels (default).
+{break}{cmd:raw}: Imports the underlying string categories as string variables.
+{break}{cmd:both}: Keeps the encoded numeric variable and creates a companion 
+string variable.
+
+{pstd}
+{bf:Resource Control}
+{break}By default, the plugin uses all available CPU threads for parallel I/O. 
+You can limit this by setting the {cmd:DTPARQUET_THREADS} environment variable 
+before running the command.
+
+
 {marker examples}{...}
 {title:Examples}
 
 {pstd}Save the current dataset to Parquet (abbreviated){p_end}
-{phang2}{cmd:. dtparquet sa mydata.parquet, re}
+{phang2}{cmd:. dtparquet sa mydata.parquet, re}{p_end}
 
 {pstd}Save partitioned output by selected variables{p_end}
-{phang2}{cmd:. dtparquet sa sales, partitionby(year region)}
+{phang2}{cmd:. dtparquet sa sales, partitionby(year region)}{p_end}
 
 {pstd}Load specific variables from a Parquet file (abbreviated){p_end}
-{phang2}{cmd:. dtparquet u id price mpg using mydata.parquet, c}
+{phang2}{cmd:. dtparquet u id price mpg using mydata.parquet, c}{p_end}
 
 {pstd}Import large IDs from a foreign Parquet file as strings{p_end}
-{phang2}{cmd:. dtparquet use using big_ids.parquet, allstring clear}
+{phang2}{cmd:. dtparquet use using big_ids.parquet, allstring clear}{p_end}
 
 {pstd}Export a .dta file to Parquet while preserving the active frame{p_end}
-{phang2}{cmd:. dtparquet export results.parquet using raw_data.dta, replace}
+{phang2}{cmd:. dtparquet export results.parquet using raw_data.dta, replace}{p_end}
 
 {pstd}Convert a Parquet file to Stata format on disk{p_end}
-{phang2}{cmd:. dtparquet import final.dta using results.parquet, replace allstring}
+{phang2}{cmd:. dtparquet import final.dta using results.parquet, replace allstring}{p_end}
 
 
 {marker troubleshooting}{...}
 {title:Troubleshooting}
 
 {phang}
-If you see a plugin mismatch or missing-binary error, run:
-{break}{cmd:. dtkit, update}
+If you see a plugin mismatch or missing-binary error, run {cmd:dtkit, update}.
 
 {phang}
 After a fresh {cmd:net install dtkit}, run {cmd:dtkit, update} once to fetch
@@ -194,7 +209,7 @@ the plugin binary.
 {phang}
 If your network blocks GitHub release assets, manually download
 {cmd:dtparquet.dll} from
-{break}{browse "https://github.com/bukanpeneliti/dtkit/releases":https://github.com/bukanpeneliti/dtkit/releases}
+{browse "https://github.com/bukanpeneliti/dtkit/releases":GitHub Releases}
 and place it in your dtkit ado directory (typically {cmd:`c(sysdir_plus)'d/}).
 
 {phang}
@@ -206,12 +221,8 @@ loaded plugin version.
 {title:Author}
 
 {pstd}
-Hafiz Arfyanto
-{p_end}
-{pstd}
-Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}
-{p_end}
-{pstd}
+Hafiz Arfyanto{break}
+Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{break}
 GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}
 
 {pstd}

--- a/ado/dtstat.sthlp
+++ b/ado/dtstat.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.0.2  25jun2025}{...}
+{* *! version 1.0.2  11mar2026}{...}
 {vieweralsosee "[R] summarize" "help summarize"}{...}
 {vieweralsosee "[R] collapse" "help collapse"}{...}
 {vieweralsosee "[R] tabstat" "help tabstat"}{...}
@@ -10,15 +10,13 @@
 {vieweralsosee "dtparquet" "help dtparquet"}{...}
 {viewerjumpto "Syntax" "dtstat##syntax"}{...}
 {viewerjumpto "Description" "dtstat##description"}{...}
-{viewerjumpto "Links to PDF documentation" "dtstat##linkspdf"}{...}
 {viewerjumpto "Options" "dtstat##options"}{...}
 {viewerjumpto "Examples" "dtstat##examples"}{...}
 {viewerjumpto "Stored results" "dtstat##results"}{...}
 {viewerjumpto "Author" "dtstat##author"}{...}
 {viewerjumpto "Also see" "dtstat##also_see"}{...}
 {p2colset 1 16 18 2}{...}
-{p2col:{bf:[D] dtstat} {hline 2}}Produce descriptive statistics dataset{p_end}
-{p2col:}({mansection D dtstat:View complete PDF manual entry}){p_end}
+{p2col:{bf:dtstat} {hline 2}}Produce descriptive statistics dataset{p_end}
 {p2colreset}{...}
 
 
@@ -26,12 +24,7 @@
 {title:Syntax}
 
 {p 8 16 2}
-{cmd:dtstat}
-{varlist}
-[{ifin}]
-[{weight}]
-[{cmd:using} {it:{help filename}}]
-[{cmd:,} {it:options}]
+{cmd:dtstat} {varlist} [{ifin}] [{weight}] [{cmd:using} {it:{help filename}}] [{cmd:,} {it:options}]
 
 {synoptset 24 tabbed}{...}
 {synopthdr}
@@ -73,13 +66,6 @@ The output dataset includes rows for each group and additional rows for overall 
 {opt fast} utilizes {cmd:gcollapse} from the {cmd:gtools} package for improved performance with large datasets.
 
 
-{marker linkspdf}{...}
-{title:Links to PDF documentation}
-
-{pstd}
-No PDF documentation is available for this user-written command.
-
-
 {marker options}{...}
 {title:Options}
 
@@ -102,19 +88,43 @@ The default list includes {cmd:count mean median min max}.
 {cmd:dtstat} supports any statistic from {help collapse}.
 Common statistics include:
 
-{pmore2}
-{cmd:count} - number of nonmissing observations{break}
-{cmd:mean} - arithmetic mean{break}
-{cmd:median} - median (50th percentile){break}
-{cmd:min} - minimum value{break}
-{cmd:max} - maximum value{break}
-{cmd:sd} - standard deviation{break}
-{cmd:sum} - sum of values{break}
-{cmd:p}{it:##} - ##th percentile (e.g., {cmd:p25} for the 25th percentile, {cmd:p75} for the 75th percentile){break}
-{cmd:iqr} - interquartile range (difference between the 75th and 25th percentiles){break}
-{cmd:first} - first observation in group{break}
-{cmd:last} - last observation in group{break}
-{cmd:firstnm} - first nonmissing observation in group{break}
+{phang2}
+{cmd:count} - number of nonmissing observations
+
+{phang2}
+{cmd:mean} - arithmetic mean
+
+{phang2}
+{cmd:median} - median (50th percentile)
+
+{phang2}
+{cmd:min} - minimum value
+
+{phang2}
+{cmd:max} - maximum value
+
+{phang2}
+{cmd:sd} - standard deviation
+
+{phang2}
+{cmd:sum} - sum of values
+
+{phang2}
+{cmd:p}{it:##} - ##th percentile (e.g., {cmd:p25} for the 25th percentile, {cmd:p75} for the 75th percentile)
+
+{phang2}
+{cmd:iqr} - interquartile range (difference between the 75th and 25th percentiles)
+
+{phang2}
+{cmd:first} - first observation in group
+
+{phang2}
+{cmd:last} - last observation in group
+
+{phang2}
+{cmd:firstnm} - first nonmissing observation in group
+
+{phang2}
 {cmd:lastnm} - last nonmissing observation in group
 
 {phang}
@@ -205,9 +215,10 @@ The dataset includes additional rows for overall totals.{p_end}
 {marker author}{...}
 {title:Author}
 
-{pstd}Hafiz Arfyanto{p_end}
-{pstd}Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{p_end}
-{pstd}GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}{p_end}
+{pstd}
+Hafiz Arfyanto{break}
+Email: {browse "mailto:bukanpeneliti@gmail.com":bukanpeneliti@gmail.com}{break}
+GitHub: {browse "https://github.com/bukanpeneliti/dtkit":https://github.com/bukanpeneliti/dtkit}
 
 {pstd}
 For questions and suggestions, visit {browse "https://github.com/bukanpeneliti/dtkit/issues":GitHub Issues}.


### PR DESCRIPTION
This PR performs a comprehensive cleanup of the .sthlp documentation:
- Modernized layouts using phang2 and break for better readability.
- Removed dead 'Links to PDF documentation' sections and manual entry links.
- Simplified syntax diagrams and headings.
- Added detailed 'Remarks' to dtparquet regarding precision, filtering, and categorical data.
- Standardized version headers and date formats.

Fixes #19