### PR TITLE
chore: bump dtkit and dtparquet versions to 2.0.2

### DIFF
--- a/ado/dtkit.ado
+++ b/ado/dtkit.ado
@@ -1,4 +1,4 @@
-*! version 2.0.1 11mar2026
+*! version 2.0.2 13mar2026
 *! Program for managing the dtkit package installation
 
 capture program drop dtkit

--- a/ado/dtkit.sthlp
+++ b/ado/dtkit.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 2.0.1  11mar2026}{...}
+{* *! version 2.0.2  13mar2026}{...}
 {vieweralsosee "dtfreq" "help dtfreq"}{...}
 {vieweralsosee "dtstat" "help dtstat"}{...}
 {vieweralsosee "dtmeta" "help dtmeta"}{...}
@@ -146,7 +146,7 @@ Available options are:
 {phang2}{cmd:. dtkit, upgrade}{p_end}
 
 {pstd}Upgrade and force a specific release-tagged plugin binary{p_end}
-{phang2}{cmd:. dtkit, update tag(v2.0.0)}{p_end}
+{phang2}{cmd:. dtkit, update tag(v2.0.2)}{p_end}
 
 {pstd}Check dtparquet plugin install/version status{p_end}
 {phang2}{cmd:. dtkit, pluginstatus}{p_end}

--- a/ado/dtparquet.ado
+++ b/ado/dtparquet.ado
@@ -1,4 +1,4 @@
-*! version 2.0.1 11mar2026
+*! version 2.0.2 13mar2026
 *! 
 *! Credits & Attribution:
 *! This package (dtparquet) is inspired by and incorporates concepts 

--- a/ado/dtparquet.sthlp
+++ b/ado/dtparquet.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 2.0.1  11mar2026}{...}
+{* *! version 2.0.2  13mar2026}{...}
 {vieweralsosee "dtmeta" "help dtmeta"}{...}
 {vieweralsosee "dtkit" "help dtkit"}{...}
 {vieweralsosee "[D] use" "help use"}{...}

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,23 @@ All notable changes to the dtkit project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Package Release [v2.0.2] - 2026-03-13
+
+- **Patch release** for dtparquet `use` performance and benchmark reliability.
+- Component versions:
+  - **dtkit: v2.0.2 (Updated)**
+  - **dtparquet: v2.0.2 (Updated)**
+
+### Fixed
+
+- **dtparquet v2.0.2**:
+  - Reduced numeric sink overhead in typed `use` paths with contiguous no-null
+    fast paths.
+  - Preserved `if_filter_mode` state macro under `timer(off)` to keep test
+    behavior consistent.
+  - Consolidated benchmark and test coverage updates used for release
+    validation.
+
 ## Package Release [v2.0.1] - 2026-03-11
 
 - **Critical performance optimization** for the Rust plugin.

--- a/dtkit.pkg
+++ b/dtkit.pkg
@@ -1,10 +1,10 @@
-v 2.0.1
+v 2.0.2
 d dtkit: Data Toolkit for Stata
 d
 d Author: Hafiz Arfyanto
 d Support: email bukanpeneliti@gmail.com
 d
-d Distribution-Date: 11mar2026
+d Distribution-Date: 13mar2026
 d
 d This package provides utilities for data analysis in Stata
 d

--- a/plugin/Cargo.lock
+++ b/plugin/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "dtparquet"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "glob",
  "polars",

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "dtparquet"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Hafiz <your.email@example.com>"]
 edition = "2021"
 description = "Fast Stata plugin for Parquet I/O with metadata preservation"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # dtkit: Data Toolkit for Stata
 
 [![Stata Package](https://img.shields.io/badge/Stata-ado-blue)](https://github.com/bukanpeneliti/dtkit)
-![Version](https://img.shields.io/badge/Version-2.0.0-green)
+![Version](https://img.shields.io/badge/Version-2.0.2-green)
 ![Stata 16+](https://img.shields.io/badge/Stata-16%2B-purple)
 ![GitHub Downloads](https://img.shields.io/github/downloads/bukanpeneliti/dtkit/total)
 ![GitHub Stars](https://img.shields.io/github/stars/bukanpeneliti/dtkit?style=social)
@@ -58,7 +58,7 @@ dtkit, upgrade
 If you want to pin a specific release asset, use:
 
 ```stata
-dtkit, update tag(v2.0.0)
+dtkit, update tag(v2.0.2)
 ```
 
 Check current plugin status with:
@@ -182,7 +182,7 @@ If you use `dtkit` in your research, please cite:
 **Plain Text:**
 
 ```text
-Hafiz Arfyanto (2026). dtkit: Data Toolkit for Stata. Version 2.0.0.
+Hafiz Arfyanto (2026). dtkit: Data Toolkit for Stata. Version 2.0.2.
 Retrieved from https://github.com/bukanpeneliti/dtkit
 ```
 
@@ -192,7 +192,7 @@ Retrieved from https://github.com/bukanpeneliti/dtkit
 @misc{arfyanto2026dtkit,
   author = {Hafiz Arfyanto},
   title = {dtkit: Data Toolkit for Stata},
-  version = {2.0.0},
+  version = {2.0.2},
   year = {2026},
   url = {https://github.com/bukanpeneliti/dtkit},
   note = {Stata package for data exploration and analysis}


### PR DESCRIPTION
## Summary
- Bump package and plugin versions to `2.0.2` across ADO/help/package metadata.
- Update release-facing docs/examples (README badge, tagged update example, citation version).
- Add changelog entry for `v2.0.2` covering this patch release.

## Files updated
- `ado/dtparquet.ado`, `ado/dtparquet.sthlp`
- `ado/dtkit.ado`, `ado/dtkit.sthlp`
- `plugin/Cargo.toml`, `plugin/Cargo.lock`
- `dtkit.pkg`
- `readme.md`
- `changelog.md`

## Notes
- Stacked on top of #25 to keep release metadata separate from runtime/perf code changes.